### PR TITLE
Fix g:tmruExclude default broken by myself in the last commit.

### DIFF
--- a/plugin/tmru.vim
+++ b/plugin/tmru.vim
@@ -68,9 +68,9 @@ if !exists("g:tmruExclude") "{{{2
                 \ . '\|\.tmp$'
                 \ . '\|'. s:PS .'.git'. s:PS .'\(COMMIT_EDITMSG\|git-rebase-todo\)$'
                 \ . '\|'. s:PS .'quickfix$'
-                \ . '\|__.\{-}__$\|'
+                \ . '\|__.\{-}__$'
                 \ . '\|^fugitive:'
-                \ . substitute(escape(&suffixes, '~.*$^'), '\\\@<!,', '$\\|', 'g') .'$' " &suffixes, ORed (split on (not escaped) comma)
+                \ . '\|' . substitute(escape(&suffixes, '~.*$^'), '\\\@<!,', '$\\|', 'g') .'$' " &suffixes, ORed (split on (not escaped) comma)
     unlet s:PS
 endif
 


### PR DESCRIPTION
This was broken in the last commit (d377ae7cc5d53a398f5a069e67d622671a623786).
