### PR TITLE
Fix handling of errors caught on edit call.

### DIFF
--- a/plugin/tmru.vim
+++ b/plugin/tmru.vim
@@ -253,9 +253,11 @@ function! TmruEdit(filename) "{{{3
                 let file = tlib#arg#Ex(filename)
                 " TLogVAR file
                 exec 'edit '. file
+            catch /E325/
+                " swap file exists, let the user handle it
             catch
                 echohl error
-                echom v:errmsg
+                echom v:exception
                 echohl NONE
             endtry
             return 1


### PR DESCRIPTION
An issue (ervandew/eclim#154) was brought up by one of my users, where when using tmru to open a file that is currently open in another vim instance, they would get an error echoed regarding an autocmd group not existing.

As described in the linked issue, I tracked this down to the fact that although my code uses `silent! autocmd! ...` to prevent any error from being raised if the autocmd group doesn't exist, vim will still set `v:errmsg` to the error message that would have been raised had `silent!` not been used. None of this is a problem until `:TRecentlyUsedFiles` is used to open a file for which a swap file already exists, causing the following catch block in tmru to execute:

```
catch
    echohl error
    echom v:errmsg
    echohl NONE
endtry
```

The problem here is that as described in `:help catch-errors`, when wrapping a command in a try/catch block, the raised error is **not** set in `v:errmsg`. Instead, the `v:exception` variable can be used to obtain the text. Since `v:errmsg` is not set by the raised error in this case, tmru will end up echoing either an empty message, or an old message set by an unrelated previous error.

The issue can be reproduced by starting a vim instance like so (replacing the location of the vim bundles accordingly):

```
$ vim -u NONE -U NONE \
  --cmd 'set nocp rtp+=~/.vim/bundle/tlib_vim,~/.vim/bundle/tmru_vim |
         ru plugin/02tlib.vim |
         ru plugin/tmru.vim' \
  ~/.vimrc
```

and then starting another instance which will trigger a silent error followed by a swap file exist error:

```
vim -u NONE -U NONE \
  --cmd 'silent! autocmd! foo_bar' \
  --cmd 'set nocp rtp+=~/.vim/bundle/tlib_vim,~/.vim/bundle/tmru_vim |
         ru plugin/02tlib.vim |
         ru plugin/tmru.vim' \
  -c 'TRecentlyUsedFiles'
```

This attached commit fixes this issue by simply echoing `v:exception` instead of `v:errmsg`. It also adds an empty catch block for `E325` so that in the case of a swap file exists error, the user doesn't get an unnecessary hit enter prompt after choosing an action to take from the existing swap file prompt.
