### PR TITLE
Only use `:drop` with GUI enabled

### DIFF
--- a/autoload/tmru.vim
+++ b/autoload/tmru.vim
@@ -42,8 +42,8 @@ endif
 
 
 if !exists('g:tmru#drop')
-    " If true, use |:drop| to edit loaded buffers.
-    let g:tmru#drop = 1   "{{{2
+    " If true, use |:drop| to edit loaded buffers (only available with GUI).
+    let g:tmru#drop = has('gui')   "{{{2
 endif
 
 


### PR DESCRIPTION
`:drop` is not available, if Vim is compiled without GUI support.

Error: E319: Sorry, the command is not available in this version.
