### PR TITLE
Do not ignore &suffixes by default, but &wildignore

### DIFF
--- a/doc/tmru.txt
+++ b/doc/tmru.txt
@@ -198,8 +198,9 @@ g:tmruSize                     (default: empty(g:tmru_file) ? 50 : 500)
     The size is smaller if viminfo is used (see |g:tmru_file|).
 
                                                     *g:tmruExclude*
-g:tmruExclude                  (default: '/te\?mp/\|vim.\{-}/\(doc\|cache\)/\|__.\{-}__$')
+g:tmruExclude                  (default: see plugin/tmru.vim)
     Ignore files matching this regexp.
+    This includes 'wildignore'.
 
                                                     *g:tmru_ignorecase*
 g:tmru_ignorecase              (default: !has('fname_case'))

--- a/plugin/tmru.vim
+++ b/plugin/tmru.vim
@@ -179,7 +179,8 @@ if !exists("g:tmruExclude") "{{{2
                 \ . '\|__.\{-}__$'
                 \ . '\|^fugitive:'
                 \ . '\|/truecrypt\d\+/'
-                \ . '\|' . substitute(escape(&suffixes, '~.*$^'), '\\\@<!,', '$\\|', 'g') .'$' " &suffixes, ORed (split on (not escaped) comma)
+                \ . '\|\(\~\|\.o\|\.swp\|\.obj\)$'  " based on Vim's default for 'suffixes'.
+                \ . '\|' . substitute(escape(&wildignore, '~.*$^'), '\\\@<!,', '$\\|', 'g') .'$' " &wildignore, ORed (split on (not escaped) comma).
     unlet s:PS
 endif
 


### PR DESCRIPTION
The Vim help for 'suffixes' says:

> Files with these suffixes get a lower priority when multiple files
> match a wildcard.

They shouldn't be ignored, e.g. '.h' is included in there by default:

> .bak,~,.o,.h,.info,.swp,.obj

The default for 'wildignore' is empty.

This adds some of the old defaults:

> ~, .o, .swp and .obj (anchored at the end)
