### PR TITLE
Improve performance of tmru#Leave with lots of buffers

### DIFF
--- a/autoload/tmru.vim
+++ b/autoload/tmru.vim
@@ -213,7 +213,7 @@ function! tmru#Leave() "{{{3
     for bufnr in range(1, bufnr('$'))
         if buflisted(bufnr)
             let bufname = fnamemodify(bufname(bufnr), ':p')
-            let [idx, item] = tmruobj.Find(bufname)
+            let [idx, item] = tmruobj.Find(bufname, filenames)
             if idx != -1
                 let item1 = s:SetSessions(item, 1)
                 let mru[idx] = item1

--- a/plugin/tmru.vim
+++ b/plugin/tmru.vim
@@ -303,15 +303,13 @@ function! s:tmruobj_prototype.Save(...) dict
 endf
 
 
-function! s:tmruobj_prototype.Find(filename) dict
+function! s:tmruobj_prototype.Find(filename, ...) dict
     let filename = s:NormalizeFilename(a:filename)
-    let idx = 0
-    for item in self.mru
-        if item[0] == filename
-            return [idx, item]
-        endif
-        let idx += 1
-    endfor
+    let filenames = a:0 ? a:1 : self.GetFilenames()
+    let idx = index(filenames, filename)
+    if idx !=# -1
+      return [idx, self.mru[idx]]
+    endif
     return [-1, []]
 endf
 


### PR DESCRIPTION
Given a lot of buffers (379), and `let g:tmruSize = 2000` quitting Vim
takes more than 4 seconds.

This patch generates the list of filenames only once, and uses `index()`
instead of a custom loop in `s:tmruobj_prototype.Find`.

Before:

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   3.963834   0.043509  tmru#Leave()
  380   3.851486   3.843960  19()
 2000   0.067058             <SNR>211_SetSessions()
   15   0.026044   0.000761  <SNR>54_record()
   15   0.025283             <SNR>54_addtomrufs()
  380   0.007526             <SNR>119_NormalizeFilename()
    1   0.007486             <SNR>86_persist()
    …

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  380   3.851486   3.843960  19()
 2000              0.067058  <SNR>211_SetSessions()
    1   3.963834   0.043509  tmru#Leave()
   15              0.025283  <SNR>54_addtomrufs()
  380              0.007526  <SNR>119_NormalizeFilename()
    1              0.007486  <SNR>86_persist()
    …

After:

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   0.134069   0.038920  tmru#Leave()
 2000   0.066134             <SNR>211_SetSessions()
  379   0.027213   0.020314  19()
   15   0.021082   0.000685  <SNR>54_record()
   15   0.020398             <SNR>54_addtomrufs()
    …

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
 2000              0.066134  <SNR>211_SetSessions()
    1   0.134069   0.038920  tmru#Leave()
   15              0.020398  <SNR>54_addtomrufs()
  379   0.027213   0.020314  19()
  379              0.006899  <SNR>119_NormalizeFilename()
    1              0.005769  <SNR>86_persist()
    …